### PR TITLE
feat: add GitHub Pages site for sharing analysis notebooks and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,8 @@ __pycache__/
 _bookdown_files/
 **/*.quarto_ipynb
 .claude/settings.local.json
+
+# GitHub Pages site build artifacts
+site/_site/
+site/.quarto/
+site/_freeze/

--- a/build-site.sh
+++ b/build-site.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# build-site.sh -- Assemble and render the GitHub Pages site.
+#
+# Usage:
+#   ./build-site.sh              # Build the site locally
+#   ./build-site.sh --publish    # Build and publish to gh-pages branch
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+SITE_DIR="$REPO_ROOT/site"
+
+echo "==> Syncing content into site/ ..."
+
+# Analysis notebooks
+mkdir -p "$SITE_DIR/analysis"
+rsync -a --delete \
+  --include='*.qmd' \
+  --include='_notebook_setup.R' \
+  --exclude='*' \
+  "$REPO_ROOT/analysis/" "$SITE_DIR/analysis/"
+
+# Docs (excluding agent_work)
+mkdir -p "$SITE_DIR/docs/diagrams"
+rsync -a --delete --exclude='agent_work' \
+  "$REPO_ROOT/docs/" "$SITE_DIR/docs/"
+
+# README
+cp "$REPO_ROOT/README.md" "$SITE_DIR/README.md"
+
+# Snakemake report (if present)
+if ls "$REPO_ROOT"/report*.html 2>/dev/null 1>&2; then
+  cp "$REPO_ROOT"/report*.html "$SITE_DIR/"
+  echo "    Copied Snakemake report."
+else
+  echo "    No Snakemake report found (skipping)."
+fi
+
+# Create symlinks for data dependencies so notebooks can render
+for dir in R config results resources manuscript; do
+  target="$REPO_ROOT/$dir"
+  link="$SITE_DIR/$dir"
+  if [ -d "$target" ]; then
+    ln -sfn "$target" "$link"
+  fi
+done
+
+# Symlink styles.css and bibliography for notebooks that reference them
+[ -f "$REPO_ROOT/styles.css" ] && ln -sfn "$REPO_ROOT/styles.css" "$SITE_DIR/styles.css"
+
+# Sentinel file so here::here() resolves inside site/
+touch "$SITE_DIR/.here"
+
+echo "==> Rendering site ..."
+cd "$SITE_DIR"
+quarto render
+
+echo "==> Site built at $SITE_DIR/_site/"
+
+if [ "${1:-}" = "--publish" ]; then
+  echo "==> Publishing to gh-pages branch ..."
+  quarto publish gh-pages --no-browser
+fi

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,22 @@
+# Build output
+_site/
+.quarto/
+
+# Synced content (copied by build-site.sh, not version-controlled here)
+analysis/
+docs/
+README.md
+
+# Symlinks to repo data directories
+R
+config
+results
+resources
+manuscript
+styles.css
+
+# Sentinel
+.here
+
+# Snakemake reports
+report*.html

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -1,0 +1,50 @@
+project:
+  type: website
+  output-dir: _site
+
+website:
+  title: "Q100 Variant Benchmark"
+  navbar:
+    left:
+      - text: Home
+        href: index.qmd
+      - text: Analysis Notebooks
+        menu:
+          - text: Benchmarkset Characterization
+            href: analysis/benchmarkset_characterization.qmd
+          - text: Benchmark Difficult Regions
+            href: analysis/benchmark_difficult.qmd
+          - text: Genomic Context Analysis
+            href: analysis/genomic_context_analysis.qmd
+          - text: Benchmark Exclusions
+            href: analysis/benchmark_exclusions.qmd
+          - text: Interval Size Distributions
+            href: analysis/benchmark_interval_size_distributions.qmd
+          - text: External Evaluation
+            href: analysis/external_evaluation.qmd
+      - text: Documentation
+        menu:
+          - text: Architecture
+            href: docs/architecture.md
+          - text: Data Dictionary
+            href: docs/data-dictionary.md
+          - text: API Reference
+            href: docs/api-reference.md
+          - text: Pipeline Outputs
+            href: docs/pipeline-outputs.md
+          - text: Plot Themes Guide
+            href: docs/plot_themes_guide.md
+          - text: Troubleshooting
+            href: docs/troubleshooting.md
+      - text: R Reference
+        href: r-reference.qmd
+      - text: Pipeline README
+        href: README.md
+
+execute:
+  freeze: auto
+
+format:
+  html:
+    theme: cosmo
+    toc: true

--- a/site/index.qmd
+++ b/site/index.qmd
@@ -1,0 +1,29 @@
+---
+title: "GIAB Q100 HG002 Variant Benchmark"
+---
+
+This site shares analysis notebooks, documentation, and R reference materials
+for the GIAB Q100 HG002 variant benchmark project.
+
+## Analysis Notebooks
+
+- [Benchmarkset Characterization](analysis/benchmarkset_characterization.qmd) -- Primary analysis of benchmark sets
+- [Benchmark Difficult Regions](analysis/benchmark_difficult.qmd) -- Coverage analysis in difficult genomic regions
+- [Genomic Context Analysis](analysis/genomic_context_analysis.qmd) -- Detailed genomic context overlap analysis
+- [Benchmark Exclusions](analysis/benchmark_exclusions.qmd) -- Exclusion analysis for v5.0q benchmarks
+- [Interval Size Distributions](analysis/benchmark_interval_size_distributions.qmd) -- Size distribution analysis
+- [External Evaluation](analysis/external_evaluation.qmd) -- External benchmark comparisons
+
+## Documentation
+
+- [Architecture](docs/architecture.md) -- System architecture overview
+- [Data Dictionary](docs/data-dictionary.md) -- Metric definitions and data structures
+- [API Reference](docs/api-reference.md) -- Python script API reference
+- [Pipeline Outputs](docs/pipeline-outputs.md) -- Complete output file catalog
+- [Plot Themes Guide](docs/plot_themes_guide.md) -- Visualization theming guide
+- [Troubleshooting](docs/troubleshooting.md) -- Common issues and solutions
+
+## Reference
+
+- [R Functions Reference](r-reference.qmd) -- Documentation for R helper scripts
+- [Pipeline README](README.md) -- Snakemake pipeline overview and usage

--- a/site/r-reference.qmd
+++ b/site/r-reference.qmd
@@ -1,0 +1,63 @@
+---
+title: "R Functions Reference"
+---
+
+## Overview
+
+The R source files in `R/` provide data loading, schema management, caching,
+and plot theming for the analysis notebooks.
+
+| File | Purpose |
+|------|---------|
+| `data_loading.R` | All data loading functions with caching and validation |
+| `schemas.R` | Arrow schema registry, factor levels, validation rules |
+| `cache.R` | Parquet caching system with zstd compression |
+| `plot_themes.R` | Plot theming and visualization helpers |
+
+---
+
+## data_loading.R
+
+```{r}
+#| echo: false
+#| output: asis
+cat("```r\n")
+cat(readLines(here::here("R", "data_loading.R")), sep = "\n")
+cat("\n```\n")
+```
+
+---
+
+## schemas.R
+
+```{r}
+#| echo: false
+#| output: asis
+cat("```r\n")
+cat(readLines(here::here("R", "schemas.R")), sep = "\n")
+cat("\n```\n")
+```
+
+---
+
+## cache.R
+
+```{r}
+#| echo: false
+#| output: asis
+cat("```r\n")
+cat(readLines(here::here("R", "cache.R")), sep = "\n")
+cat("\n```\n")
+```
+
+---
+
+## plot_themes.R
+
+```{r}
+#| echo: false
+#| output: asis
+cat("```r\n")
+cat(readLines(here::here("R", "plot_themes.R")), sep = "\n")
+cat("\n```\n")
+```


### PR DESCRIPTION
Adds a Quarto website project under site/ with a build script that:
- Syncs analysis notebooks, docs (excluding agent_work), and README
- Symlinks R/, config/, results/ so notebooks can render locally
- Supports `--publish` flag for deploying to gh-pages branch

https://claude.ai/code/session_01NQGQuQBXjWhU3Hsd5evD83