### PR TITLE
Add PDF output alongside PNG for R-generated figures

### DIFF
--- a/analysis/benchmark_difficult.qmd
+++ b/analysis/benchmark_difficult.qmd
@@ -164,6 +164,12 @@ ggsave(
   height = 4.5,
   dpi = 300
 )
+ggsave(
+  filename = here("manuscript", "figs", "genomic_context_variant_counts.pdf"),
+  plot = variant_count_plt,
+  width = 8.5,
+  height = 4.5
+)
 ```
 
 ### Supplemental: Fold Change by Variant Size Bin
@@ -268,6 +274,12 @@ ggsave(
   width = 8,
   height = 6,
   dpi = 300
+)
+ggsave(
+  filename = here("manuscript", "figs", "genomic_context_fold_change_by_size.pdf"),
+  plot = fold_change_size_plt,
+  width = 8,
+  height = 6
 )
 ```
 

--- a/analysis/benchmark_exclusions.qmd
+++ b/analysis/benchmark_exclusions.qmd
@@ -358,6 +358,12 @@ ggsave(
   height = 8,
   dpi = 300
 )
+ggsave(
+  filename = here::here("manuscript", "figs", "grch38_exclusion_upset.pdf"),
+  plot = grch38_upset_plt,
+  width = 12,
+  height = 8
+)
 ```
 
 ### All References Exclusion Patterns (Supplemental)
@@ -412,6 +418,12 @@ ggsave(
   width = 12,
   height = 8,
   dpi = 300
+)
+ggsave(
+  filename = here::here("manuscript", "figs", "grch38_exclusion_var_upset.pdf"),
+  plot = grch38_upset_var_plt,
+  width = 12,
+  height = 8
 )
 ```
 

--- a/analysis/benchmark_interval_size_distributions.qmd
+++ b/analysis/benchmark_interval_size_distributions.qmd
@@ -134,6 +134,12 @@ ggsave(
   height = 7,
   dpi = 300
 )
+ggsave(
+  here("manuscript/figs/benchmark_intervals.pdf"),
+  interval_plt,
+  width = 8,
+  height = 7
+)
 ```
 
 ## Interval Summary Table

--- a/analysis/benchmarkset_characterization.qmd
+++ b/analysis/benchmarkset_characterization.qmd
@@ -228,6 +228,12 @@ ggsave(
   height = 4,
   dpi = 300
 )
+ggsave(
+  filename = here("manuscript", "figs", "var_len_dist.pdf"),
+  plot = combined_var_len_dist_plt,
+  width = 8,
+  height = 4
+)
 ```
 
 
@@ -303,6 +309,12 @@ ggsave(
   height = 4,
   dpi = 300
 )
+ggsave(
+  filename = here("manuscript", "figs", "benchmark_region_size_change.pdf"),
+  plot = coverage_change_plt,
+  width = 8,
+  height = 4
+)
 ```
 
 ## Variant Fold Change by Genomic Context
@@ -377,5 +389,11 @@ ggsave(
   width = 8,
   height = 8,
   dpi = 300
+)
+ggsave(
+  filename = here("manuscript", "figs", "combined_coverage_variant_change.pdf"),
+  plot = combined_coverage_variant_plt,
+  width = 8,
+  height = 8
 )
 ```

--- a/analysis/external_evaluation.qmd
+++ b/analysis/external_evaluation.qmd
@@ -323,6 +323,11 @@ ggsave(
   plot = smvar_flow,
   width = 8, height = 8, dpi = 300
 )
+ggsave(
+  filename = here("manuscript", "figs", "smvar_strat_flow.pdf"),
+  plot = smvar_flow,
+  width = 8, height = 8
+)
 ```
 
 
@@ -413,6 +418,11 @@ ggsave(
   plot = combined_eval_plt,
   width = 8, height = 8, dpi = 300
 )
+ggsave(
+  filename = here("manuscript", "figs", "combined_eval.pdf"),
+  plot = combined_eval_plt,
+  width = 8, height = 8
+)
 ```
 
 ## Combined Evaluation Figure (Correct in Callset)
@@ -430,6 +440,11 @@ ggsave(
   filename = here("manuscript", "figs", "combined_eval_callset.png"),
   plot = combined_eval_cs_plt,
   width = 8, height = 8, dpi = 300
+)
+ggsave(
+  filename = here("manuscript", "figs", "combined_eval_callset.pdf"),
+  plot = combined_eval_cs_plt,
+  width = 8, height = 8
 )
 ```
 
@@ -614,6 +629,11 @@ ggsave(
   filename = here("manuscript", "figs", "ride_estimates.png"),
   plot = ci_forest_plt,
   width = 8, height = 8, dpi = 300
+)
+ggsave(
+  filename = here("manuscript", "figs", "ride_estimates.pdf"),
+  plot = ci_forest_plt,
+  width = 8, height = 8
 )
 ```
 
@@ -849,6 +869,11 @@ ggsave(
   filename = here("manuscript", "figs", "ride_estimates_callset.png"),
   plot = ci_forest_cs_plt,
   width = 8, height = 8, dpi = 300
+)
+ggsave(
+  filename = here("manuscript", "figs", "ride_estimates_callset.pdf"),
+  plot = ci_forest_cs_plt,
+  width = 8, height = 8
 )
 ```
 

--- a/analysis/genomic_context_analysis.qmd
+++ b/analysis/genomic_context_analysis.qmd
@@ -181,6 +181,12 @@ ggsave(
   height = 8,
   dpi = 300
 )
+ggsave(
+  filename = here::here("manuscript", "figs", "genomic_context_coverage.pdf"),
+  plot = coverage_combined_plt,
+  width = 8,
+  height = 8
+)
 ```
 
 ## Coverage Change Across Benchmark Versions
@@ -244,6 +250,12 @@ ggsave(
   width = 8,
   height = 5,
   dpi = 300
+)
+ggsave(
+  filename = here::here("manuscript", "figs", "genomic_context_coverage_change.pdf"),
+  plot = coverage_change_plt,
+  width = 8,
+  height = 5
 )
 ```
 

--- a/analysis/use_case_evaluation.qmd
+++ b/analysis/use_case_evaluation.qmd
@@ -458,6 +458,12 @@ ggsave(
   height = 10,
   dpi = 300
 )
+ggsave(
+  filename = here("manuscript", "figs", "use_case_smvar.pdf"),
+  plot = combined_smvar_plt,
+  width = 8,
+  height = 10
+)
 ```
 
 ### Figure Legend
@@ -626,6 +632,12 @@ ggsave(
   height = 8,
   dpi = 300
 )
+ggsave(
+  filename = here("manuscript", "figs", "use_case_stvar_ont.pdf"),
+  plot = combined_ont_plt,
+  width = 8,
+  height = 8
+)
 ```
 
 ### HiFi: Sniffles1 vs Sniffles2
@@ -646,6 +658,12 @@ ggsave(
   width = 8,
   height = 8,
   dpi = 300
+)
+ggsave(
+  filename = here("manuscript", "figs", "use_case_stvar_hifi.pdf"),
+  plot = combined_hifi_plt,
+  width = 8,
+  height = 8
 )
 ```
 

--- a/scripts/create_grch38_debug_subset.py
+++ b/scripts/create_grch38_debug_subset.py
@@ -200,7 +200,9 @@ def classify_variant(ref: str, alt: str, info: dict[str, str]) -> str:
     return "COMPLEX"
 
 
-def variant_size_bp(ref: str, alt: str, start0: int, end0: int, info: dict[str, str]) -> int:
+def variant_size_bp(
+    ref: str, alt: str, start0: int, end0: int, info: dict[str, str]
+) -> int:
     svlen = parse_svlen(info)
     if svlen is not None:
         return max(1, svlen)
@@ -479,7 +481,8 @@ def main() -> None:
             for region in REGIONS
         ],
         "constraint_checks": {
-            "one_region_per_chromosome": len({r.chrom for r in REGIONS}) == len(REGIONS),
+            "one_region_per_chromosome": len({r.chrom for r in REGIONS})
+            == len(REGIONS),
             "autosome_count": sum(1 for r in REGIONS if r.chrom[3:].isdigit()),
             "includes_chrX": any(r.chrom == "chrX" for r in REGIONS),
             "includes_chrY": any(r.chrom == "chrY" for r in REGIONS),
@@ -511,7 +514,9 @@ def main() -> None:
 
     summary_path = output_root / "subset_summary.json"
     ensure_parent(summary_path)
-    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8"
+    )
 
     write_readme(output_root)
     print(f"Wrote GRCh38 debug subset to: {output_root}")

--- a/scripts/extract_sv_metrics.py
+++ b/scripts/extract_sv_metrics.py
@@ -26,10 +26,22 @@ STRAT_DIR = PROJ_DIR / "resources" / "stratifications"
 OUTPUT_DIR = PROJ_DIR / "results" / "use_case" / "stvar"
 
 CALLSET_CONFIG: dict[tuple[str, str], str] = {
-    ("HiFi", "sniffles1"): "GRCh38_HG002_T~T2TQ100v1.1_Q~HiFi-Snifpub-sniffles1_TR~none_GRCh38_HG002-T2TQ100v1.1-dipz2k_stvar-excluded",
-    ("HiFi", "sniffles2"): "GRCh38_HG002_T~T2TQ100v1.1_Q~HiFi-Snifpub-sniffles2_TR~none_GRCh38_HG002-T2TQ100v1.1-dipz2k_stvar-excluded",
-    ("ONT", "sniffles1"): "GRCh38_HG002_T~T2TQ100v1.1_Q~ONT-Snifpub-sniffles1_TR~none_GRCh38_HG002-T2TQ100v1.1-dipz2k_stvar-excluded",
-    ("ONT", "sniffles2"): "GRCh38_HG002_T~T2TQ100v1.1_Q~ONT-Snifpub-sniffles2_TR~none_GRCh38_HG002-T2TQ100v1.1-dipz2k_stvar-excluded",
+    (
+        "HiFi",
+        "sniffles1",
+    ): "GRCh38_HG002_T~T2TQ100v1.1_Q~HiFi-Snifpub-sniffles1_TR~none_GRCh38_HG002-T2TQ100v1.1-dipz2k_stvar-excluded",
+    (
+        "HiFi",
+        "sniffles2",
+    ): "GRCh38_HG002_T~T2TQ100v1.1_Q~HiFi-Snifpub-sniffles2_TR~none_GRCh38_HG002-T2TQ100v1.1-dipz2k_stvar-excluded",
+    (
+        "ONT",
+        "sniffles1",
+    ): "GRCh38_HG002_T~T2TQ100v1.1_Q~ONT-Snifpub-sniffles1_TR~none_GRCh38_HG002-T2TQ100v1.1-dipz2k_stvar-excluded",
+    (
+        "ONT",
+        "sniffles2",
+    ): "GRCh38_HG002_T~T2TQ100v1.1_Q~ONT-Snifpub-sniffles2_TR~none_GRCh38_HG002-T2TQ100v1.1-dipz2k_stvar-excluded",
 }
 
 CONTEXTS = ["HP", "TR", "SD", "MAP"]
@@ -55,16 +67,21 @@ def find_truvari_dir(top_dir: Path) -> Path:
         if p.is_dir() and p.name != "phab_bench":
             if (p / "refine.variant_summary.json").exists():
                 return p
-    raise FileNotFoundError(f"No truvari output dir with refine.variant_summary.json in {top_dir}")
+    raise FileNotFoundError(
+        f"No truvari output dir with refine.variant_summary.json in {top_dir}"
+    )
 
 
 def run_truvari_stratify(bed_path: Path, truvari_dir: Path, output_path: Path) -> None:
     """Run truvari stratify on a truvari output directory via Python API."""
-    stratify_main([
-        str(bed_path),
-        str(truvari_dir),
-        "-o", str(output_path),
-    ])
+    stratify_main(
+        [
+            str(bed_path),
+            str(truvari_dir),
+            "-o",
+            str(output_path),
+        ]
+    )
 
 
 def get_refine_vcfs(run_dir: Path) -> dict[str, Path]:
@@ -96,29 +113,35 @@ def main() -> None:
         with open(run_dir / "refine.variant_summary.json") as f:
             summary = json.load(f)
 
-        strat_rows.append({
-            "platform": platform,
-            "callset": callset,
-            "context": "Overall",
-            "tp": summary["TP-comp"],
-            "fp": summary["FP"],
-            "fn": summary["FN"],
-            "recall": round(summary["recall"], 4),
-            "precision": round(summary["precision"], 4),
-        })
+        strat_rows.append(
+            {
+                "platform": platform,
+                "callset": callset,
+                "context": "Overall",
+                "tp": summary["TP-comp"],
+                "fp": summary["FP"],
+                "fn": summary["FN"],
+                "recall": round(summary["recall"], 4),
+                "precision": round(summary["precision"], 4),
+            }
+        )
 
         # Per-context: run truvari stratify
         for context in CONTEXTS:
             bed_path = STRAT_DIR / f"GRCh38_{context}.bed.gz"
             if not bed_path.exists():
-                print(f"WARNING: {bed_path} not found, skipping {context}", file=sys.stderr)
+                print(
+                    f"WARNING: {bed_path} not found, skipping {context}",
+                    file=sys.stderr,
+                )
                 continue
 
             strat_out = OUTPUT_DIR / f"stratify_{platform}_{callset}_{context}.txt"
             run_truvari_stratify(bed_path, run_dir, strat_out)
 
             strat_df = pd.read_csv(
-                strat_out, sep="\t",
+                strat_out,
+                sep="\t",
                 names=["chrom", "start", "end", "tpbase", "tp", "fn", "fp"],
             )
             totals = strat_df[["tpbase", "tp", "fn", "fp"]].sum()
@@ -130,21 +153,33 @@ def main() -> None:
                 int(totals["fp"]),
             )
 
-            strat_rows.append({
-                "platform": platform,
-                "callset": callset,
-                "context": context,
-                "tp": int(totals["tp"]),
-                "fp": int(totals["fp"]),
-                "fn": int(totals["fn"]),
-                "recall": round(recall, 4),
-                "precision": round(precision, 4),
-            })
+            strat_rows.append(
+                {
+                    "platform": platform,
+                    "callset": callset,
+                    "context": context,
+                    "tp": int(totals["tp"]),
+                    "fp": int(totals["fp"]),
+                    "fn": int(totals["fn"]),
+                    "recall": round(recall, 4),
+                    "precision": round(precision, 4),
+                }
+            )
 
     strat_path = OUTPUT_DIR / "stratified_metrics.csv"
     with open(strat_path, "w", newline="") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["platform", "callset", "context", "tp", "fp", "fn", "recall", "precision"]
+            f,
+            fieldnames=[
+                "platform",
+                "callset",
+                "context",
+                "tp",
+                "fp",
+                "fn",
+                "recall",
+                "precision",
+            ],
         )
         writer.writeheader()
         writer.writerows(strat_rows)
@@ -160,7 +195,9 @@ def main() -> None:
         fp_df = truvari.vcf_to_df(str(vcfs["FP"]))
         fn_df = truvari.vcf_to_df(str(vcfs["FN"]))
 
-        all_types = sorted(set(tp_df["svtype"]) | set(fp_df["svtype"]) | set(fn_df["svtype"]))
+        all_types = sorted(
+            set(tp_df["svtype"]) | set(fp_df["svtype"]) | set(fn_df["svtype"])
+        )
 
         for svtype in all_types:
             tp = len(tp_df[tp_df["svtype"] == svtype])
@@ -169,21 +206,33 @@ def main() -> None:
 
             precision, recall, f1 = truvari.performance_metrics(tp, tp, fn, fp)
 
-            svtype_rows.append({
-                "platform": platform,
-                "callset": callset,
-                "svtype": svtype,
-                "tp": tp,
-                "fp": fp,
-                "fn": fn,
-                "recall": round(recall, 4) if recall is not None else 0.0,
-                "precision": round(precision, 4) if precision is not None else 0.0,
-            })
+            svtype_rows.append(
+                {
+                    "platform": platform,
+                    "callset": callset,
+                    "svtype": svtype,
+                    "tp": tp,
+                    "fp": fp,
+                    "fn": fn,
+                    "recall": round(recall, 4) if recall is not None else 0.0,
+                    "precision": round(precision, 4) if precision is not None else 0.0,
+                }
+            )
 
     svtype_path = OUTPUT_DIR / "svtype_metrics.csv"
     with open(svtype_path, "w", newline="") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["platform", "callset", "svtype", "tp", "fp", "fn", "recall", "precision"]
+            f,
+            fieldnames=[
+                "platform",
+                "callset",
+                "svtype",
+                "tp",
+                "fp",
+                "fn",
+                "recall",
+                "precision",
+            ],
         )
         writer.writeheader()
         writer.writerows(svtype_rows)
@@ -214,7 +263,15 @@ def main() -> None:
     size_path = OUTPUT_DIR / "svtype_size_counts.csv"
     with open(size_path, "w", newline="") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["platform", "callset", "category", "svtype", "size_bin", "count"]
+            f,
+            fieldnames=[
+                "platform",
+                "callset",
+                "category",
+                "svtype",
+                "size_bin",
+                "count",
+            ],
         )
         writer.writeheader()
         writer.writerows(size_rows)

--- a/scripts/make_exclusion_diagram.py
+++ b/scripts/make_exclusion_diagram.py
@@ -41,25 +41,42 @@ from pathlib import Path
 
 # ---------- colour palette (colorblind-friendly) ----------
 C = {
-    "dip": "#B8C9E1",           # light blue — dip.bed
-    "bench": "#4A90D9",         # blue — benchmark regions
+    "dip": "#B8C9E1",  # light blue — dip.bed
+    "bench": "#4A90D9",  # blue — benchmark regions
     "asm_agnostic": "#E07B54",  # orange — asm-agnostic exclusions
-    "asm_intersect": "#8E6BB0", # purple — asm-intersect exclusions
+    "asm_intersect": "#8E6BB0",  # purple — asm-intersect exclusions
     "ref_agnostic": "#5AAA46",  # green — ref-agnostic exclusions
-    "slop": "#FADCB0",          # light orange — slop buffer
-    "break": "#D94E4E",         # red — assembly breaks
-    "excluded": "#F0F0F0",      # light grey — excluded from benchmark
+    "slop": "#FADCB0",  # light orange — slop buffer
+    "break": "#D94E4E",  # red — assembly breaks
+    "excluded": "#F0F0F0",  # light grey — excluded from benchmark
     "bg": "#FFFFFF",
 }
 
 
-def draw_bar(ax, start, end, y, height, color, edgecolor="grey",
-             linewidth=0.5, alpha=1.0, label=None, zorder=2):
+def draw_bar(
+    ax,
+    start,
+    end,
+    y,
+    height,
+    color,
+    edgecolor="grey",
+    linewidth=0.5,
+    alpha=1.0,
+    label=None,
+    zorder=2,
+):
     """Draw a horizontal bar representing a genomic interval."""
     rect = mpatches.FancyBboxPatch(
-        (start, y - height / 2), end - start, height,
-        boxstyle="round,pad=0.002", facecolor=color,
-        edgecolor=edgecolor, linewidth=linewidth, alpha=alpha, zorder=zorder,
+        (start, y - height / 2),
+        end - start,
+        height,
+        boxstyle="round,pad=0.002",
+        facecolor=color,
+        edgecolor=edgecolor,
+        linewidth=linewidth,
+        alpha=alpha,
+        zorder=zorder,
     )
     ax.add_patch(rect)
     return rect
@@ -68,11 +85,20 @@ def draw_bar(ax, start, end, y, height, color, edgecolor="grey",
 def add_bracket(ax, x1, x2, y, text, color="grey", fontsize=7):
     """Add a bracket annotation with label."""
     ax.annotate(
-        "", xy=(x1, y), xytext=(x2, y),
+        "",
+        xy=(x1, y),
+        xytext=(x2, y),
         arrowprops=dict(arrowstyle="<->", color=color, lw=1),
     )
-    ax.text((x1 + x2) / 2, y + 0.12, text, ha="center", va="bottom",
-            fontsize=fontsize, color=color)
+    ax.text(
+        (x1 + x2) / 2,
+        y + 0.12,
+        text,
+        ha="center",
+        va="bottom",
+        fontsize=fontsize,
+        color=color,
+    )
 
 
 def panel_a(ax):
@@ -80,15 +106,29 @@ def panel_a(ax):
 
     ax.set_xlim(-0.5, 24)
     ax.set_ylim(-1, 8.5)
-    ax.set_title("A. BED Operations for Exclusion Processing",
-                 fontsize=10, fontweight="bold", loc="left", pad=8)
+    ax.set_title(
+        "A. BED Operations for Exclusion Processing",
+        fontsize=10,
+        fontweight="bold",
+        loc="left",
+        pad=8,
+    )
 
     # --- Row 1: Slop ---
     y = 7.0
     ax.text(-0.3, y, "slop", fontsize=9, fontweight="bold", va="center")
     # Original interval
     draw_bar(ax, 3, 7, y + 0.5, 0.4, C["asm_agnostic"], label="Original")
-    ax.text(5, y + 0.5, "Original", ha="center", va="center", fontsize=6.5, color="white", fontweight="bold")
+    ax.text(
+        5,
+        y + 0.5,
+        "Original",
+        ha="center",
+        va="center",
+        fontsize=6.5,
+        color="white",
+        fontweight="bold",
+    )
     # After slop
     draw_bar(ax, 0.5, 9.5, y - 0.5, 0.4, C["slop"])
     draw_bar(ax, 3, 7, y - 0.5, 0.4, C["asm_agnostic"])
@@ -102,8 +142,26 @@ def panel_a(ax):
     # Two nearby intervals
     draw_bar(ax, 2, 5, y + 0.8, 0.4, C["asm_intersect"])
     draw_bar(ax, 7, 10, y + 0.8, 0.4, C["asm_intersect"])
-    ax.text(3.5, y + 0.8, "A", ha="center", va="center", fontsize=7, color="white", fontweight="bold")
-    ax.text(8.5, y + 0.8, "B", ha="center", va="center", fontsize=7, color="white", fontweight="bold")
+    ax.text(
+        3.5,
+        y + 0.8,
+        "A",
+        ha="center",
+        va="center",
+        fontsize=7,
+        color="white",
+        fontweight="bold",
+    )
+    ax.text(
+        8.5,
+        y + 0.8,
+        "B",
+        ha="center",
+        va="center",
+        fontsize=7,
+        color="white",
+        fontweight="bold",
+    )
     add_bracket(ax, 5, 7, y + 1.2, "gap < 10 kb", color="#888")
 
     # After slop (before merge)
@@ -114,7 +172,16 @@ def panel_a(ax):
 
     # After merge
     draw_bar(ax, 0, 12, y - 1.0, 0.4, C["asm_intersect"])
-    ax.text(6, y - 1.0, "Merged single region", ha="center", va="center", fontsize=6.5, color="white", fontweight="bold")
+    ax.text(
+        6,
+        y - 1.0,
+        "Merged single region",
+        ha="center",
+        va="center",
+        fontsize=6.5,
+        color="white",
+        fontweight="bold",
+    )
 
     # --- Row 3: Assembly-break filtering ---
     y = 1.5
@@ -126,8 +193,16 @@ def panel_a(ax):
     # Break markers
     ax.plot([8, 8], [y + 0.5, y + 1.1], color=C["break"], lw=2, zorder=3)
     ax.plot([9, 9], [y + 0.5, y + 1.1], color=C["break"], lw=2, zorder=3)
-    ax.text(8.5, y + 1.25, "break", ha="center", va="bottom", fontsize=6,
-            color=C["break"], fontweight="bold")
+    ax.text(
+        8.5,
+        y + 1.25,
+        "break",
+        ha="center",
+        va="bottom",
+        fontsize=6,
+        color=C["break"],
+        fontweight="bold",
+    )
     ax.text(4.5, y + 0.8, "dip.bed", ha="center", va="center", fontsize=6.5)
 
     # Exclusion regions (e.g. segdups)
@@ -140,10 +215,26 @@ def panel_a(ax):
 
     # Result — only region B overlaps break
     draw_bar(ax, 7.5, 11, y - 1.0, 0.3, C["asm_intersect"])
-    ax.text(9.25, y - 1.0, "Only B excluded", ha="center", va="center",
-            fontsize=6.5, color="white", fontweight="bold")
-    ax.text(4.5, y - 1.0, "A: no break overlap → kept", ha="center", va="center",
-            fontsize=6, color="#888", style="italic")
+    ax.text(
+        9.25,
+        y - 1.0,
+        "Only B excluded",
+        ha="center",
+        va="center",
+        fontsize=6.5,
+        color="white",
+        fontweight="bold",
+    )
+    ax.text(
+        4.5,
+        y - 1.0,
+        "A: no break overlap → kept",
+        ha="center",
+        va="center",
+        fontsize=6,
+        color="#888",
+        style="italic",
+    )
 
     ax.set_axis_off()
 
@@ -153,20 +244,40 @@ def panel_b(ax):
 
     ax.set_xlim(-1, 26)
     ax.set_ylim(-1.5, 9)
-    ax.set_title("B. Exclusion Categories and Benchmark Region Construction",
-                 fontsize=10, fontweight="bold", loc="left", pad=8)
+    ax.set_title(
+        "B. Exclusion Categories and Benchmark Region Construction",
+        fontsize=10,
+        fontweight="bold",
+        loc="left",
+        pad=8,
+    )
 
     # --- dip.bed row ---
     y = 8
     ax.text(-0.5, y, "dip.bed", fontsize=8, fontweight="bold", va="center")
     draw_bar(ax, 2, 25, y, 0.5, C["dip"])
-    ax.text(13.5, y, "Dipcall assembly regions", ha="center", va="center",
-            fontsize=7, color="#333")
+    ax.text(
+        13.5,
+        y,
+        "Dipcall assembly regions",
+        ha="center",
+        va="center",
+        fontsize=7,
+        color="#333",
+    )
 
     # --- Assembly-agnostic exclusions ---
     y = 6.2
-    ax.text(-0.5, y, "Assembly-\nagnostic", fontsize=7.5, fontweight="bold",
-            va="center", color=C["asm_agnostic"], linespacing=1.3)
+    ax.text(
+        -0.5,
+        y,
+        "Assembly-\nagnostic",
+        fontsize=7.5,
+        fontweight="bold",
+        va="center",
+        color=C["asm_agnostic"],
+        linespacing=1.3,
+    )
     # gaps (with slop)
     draw_bar(ax, 3, 3.5, y + 0.3, 0.3, C["slop"])
     draw_bar(ax, 3.1, 3.4, y + 0.3, 0.3, C["asm_agnostic"])
@@ -181,32 +292,82 @@ def panel_b(ax):
     draw_bar(ax, 20, 23, y + 0.3, 0.3, C["asm_agnostic"])
     ax.text(21.5, y + 0.65, "PAV inv.", ha="center", va="bottom", fontsize=5.5)
     # Description
-    ax.text(13.5, y - 0.3, "Entire regions excluded regardless of assembly quality",
-            ha="center", va="top", fontsize=6, color="#666", style="italic")
+    ax.text(
+        13.5,
+        y - 0.3,
+        "Entire regions excluded regardless of assembly quality",
+        ha="center",
+        va="top",
+        fontsize=6,
+        color="#666",
+        style="italic",
+    )
 
     # --- Assembly-intersect exclusions ---
     y = 4.2
-    ax.text(-0.5, y, "Assembly-\nintersect", fontsize=7.5, fontweight="bold",
-            va="center", color=C["asm_intersect"], linespacing=1.3)
+    ax.text(
+        -0.5,
+        y,
+        "Assembly-\nintersect",
+        fontsize=7.5,
+        fontweight="bold",
+        va="center",
+        color=C["asm_intersect"],
+        linespacing=1.3,
+    )
     # segdups (with slopmerge, filtered to breaks)
     draw_bar(ax, 5, 7, y + 0.3, 0.3, C["asm_intersect"])
-    ax.text(6, y + 0.65, "segdups\n(+slopmerge, breaks only)", ha="center",
-            va="bottom", fontsize=5.5)
+    ax.text(
+        6,
+        y + 0.65,
+        "segdups\n(+slopmerge, breaks only)",
+        ha="center",
+        va="bottom",
+        fontsize=5.5,
+    )
     # tandem-repeats (with slop, filtered to breaks)
     draw_bar(ax, 12, 13.5, y + 0.3, 0.3, C["asm_intersect"])
-    ax.text(12.75, y + 0.65, "TR\n(+slop, breaks only)", ha="center",
-            va="bottom", fontsize=5.5)
+    ax.text(
+        12.75,
+        y + 0.65,
+        "TR\n(+slop, breaks only)",
+        ha="center",
+        va="bottom",
+        fontsize=5.5,
+    )
     # satellites (with slopmerge, filtered)
     draw_bar(ax, 18, 20, y + 0.3, 0.3, C["asm_intersect"])
-    ax.text(19, y + 0.65, "satellites\n(+slopmerge, breaks only)", ha="center",
-            va="bottom", fontsize=5.5)
-    ax.text(13.5, y - 0.3, "Only excluded where assembly has alignment breaks",
-            ha="center", va="top", fontsize=6, color="#666", style="italic")
+    ax.text(
+        19,
+        y + 0.65,
+        "satellites\n(+slopmerge, breaks only)",
+        ha="center",
+        va="bottom",
+        fontsize=5.5,
+    )
+    ax.text(
+        13.5,
+        y - 0.3,
+        "Only excluded where assembly has alignment breaks",
+        ha="center",
+        va="top",
+        fontsize=6,
+        color="#666",
+        style="italic",
+    )
 
     # --- Ref-agnostic exclusions ---
     y = 2.2
-    ax.text(-0.5, y, "Ref-\nagnostic", fontsize=7.5, fontweight="bold",
-            va="center", color=C["ref_agnostic"], linespacing=1.3)
+    ax.text(
+        -0.5,
+        y,
+        "Ref-\nagnostic",
+        fontsize=7.5,
+        fontweight="bold",
+        va="center",
+        color=C["ref_agnostic"],
+        linespacing=1.3,
+    )
     # flanks
     draw_bar(ax, 2, 2.5, y + 0.3, 0.3, C["ref_agnostic"])
     draw_bar(ax, 25, 25.5, y + 0.3, 0.3, C["ref_agnostic"], edgecolor="grey")
@@ -221,56 +382,134 @@ def panel_b(ax):
     # self-discrep
     draw_bar(ax, 17, 17.3, y + 0.3, 0.3, C["ref_agnostic"])
     ax.text(17.15, y + 0.65, "self-\ndiscrep", ha="center", va="bottom", fontsize=5.5)
-    ax.text(13.5, y - 0.3, "Derived from assembly alignments and variant calls (reference-independent)",
-            ha="center", va="top", fontsize=6, color="#666", style="italic")
+    ax.text(
+        13.5,
+        y - 0.3,
+        "Derived from assembly alignments and variant calls (reference-independent)",
+        ha="center",
+        va="top",
+        fontsize=6,
+        color="#666",
+        style="italic",
+    )
 
     # --- Subtraction arrow ---
     y_arrow = 0.8
-    ax.annotate("", xy=(13.5, 0.55), xytext=(13.5, 1.2),
-                arrowprops=dict(arrowstyle="->", color="#333", lw=1.5))
-    ax.text(14.5, 0.9, "subtract all\nexclusions", ha="left", va="center",
-            fontsize=6.5, color="#555", style="italic")
+    ax.annotate(
+        "",
+        xy=(13.5, 0.55),
+        xytext=(13.5, 1.2),
+        arrowprops=dict(arrowstyle="->", color="#333", lw=1.5),
+    )
+    ax.text(
+        14.5,
+        0.9,
+        "subtract all\nexclusions",
+        ha="left",
+        va="center",
+        fontsize=6.5,
+        color="#555",
+        style="italic",
+    )
 
     # --- Benchmark regions ---
     y = 0
-    ax.text(-0.5, y, "benchmark\n.bed", fontsize=8, fontweight="bold", va="center",
-            color=C["bench"])
+    ax.text(
+        -0.5,
+        y,
+        "benchmark\n.bed",
+        fontsize=8,
+        fontweight="bold",
+        va="center",
+        color=C["bench"],
+    )
     # Draw full dip.bed background (excluded = grey)
     draw_bar(ax, 2, 25, y, 0.5, C["excluded"], edgecolor="#ccc", linewidth=0.3)
     # Overlay benchmark (non-excluded) segments — gaps where exclusions were
-    bench_segs = [(2.5, 3), (3.5, 5), (7.8, 8), (11, 12), (13.5, 14),
-                  (14.5, 15), (16.5, 17), (17.3, 18), (23, 25)]
+    bench_segs = [
+        (2.5, 3),
+        (3.5, 5),
+        (7.8, 8),
+        (11, 12),
+        (13.5, 14),
+        (14.5, 15),
+        (16.5, 17),
+        (17.3, 18),
+        (23, 25),
+    ]
     for s, e in bench_segs:
         draw_bar(ax, s, e, y, 0.5, C["bench"])
 
-    ax.text(13.5, y - 0.6, "dip.bed − (assembly-agnostic ∪ assembly-intersect ∪ ref-agnostic) = benchmark.bed",
-            ha="center", va="top", fontsize=7, fontweight="bold", color="#333")
+    ax.text(
+        13.5,
+        y - 0.6,
+        "dip.bed − (assembly-agnostic ∪ assembly-intersect ∪ ref-agnostic) = benchmark.bed",
+        ha="center",
+        va="top",
+        fontsize=7,
+        fontweight="bold",
+        color="#333",
+    )
 
     ax.set_axis_off()
 
 
 def main():
-    fig, axes = plt.subplots(2, 1, figsize=(12, 10),
-                              gridspec_kw={"height_ratios": [1, 1], "hspace": 0.3})
+    fig, axes = plt.subplots(
+        2, 1, figsize=(12, 10), gridspec_kw={"height_ratios": [1, 1], "hspace": 0.3}
+    )
 
     panel_a(axes[0])
     panel_b(axes[1])
 
     # Legend
     legend_elements = [
-        mpatches.Patch(facecolor=C["dip"], edgecolor="grey", label="Dipcall assembly regions (dip.bed)"),
-        mpatches.Patch(facecolor=C["bench"], edgecolor="grey", label="Final benchmark regions"),
-        mpatches.Patch(facecolor=C["asm_agnostic"], edgecolor="grey", label="Assembly-agnostic exclusions (gaps, VDJ, errors, PAV inv.)"),
-        mpatches.Patch(facecolor=C["asm_intersect"], edgecolor="grey", label="Assembly-intersect exclusions (segdups, TR, satellites)"),
-        mpatches.Patch(facecolor=C["ref_agnostic"], edgecolor="grey", label="Ref-agnostic exclusions (flanks, SVs∩repeats, self-discrep)"),
-        mpatches.Patch(facecolor=C["slop"], edgecolor="grey", label="Slop buffer (±15 kb)"),
-        mpatches.Patch(facecolor=C["break"], edgecolor="grey", label="Assembly alignment break"),
+        mpatches.Patch(
+            facecolor=C["dip"],
+            edgecolor="grey",
+            label="Dipcall assembly regions (dip.bed)",
+        ),
+        mpatches.Patch(
+            facecolor=C["bench"], edgecolor="grey", label="Final benchmark regions"
+        ),
+        mpatches.Patch(
+            facecolor=C["asm_agnostic"],
+            edgecolor="grey",
+            label="Assembly-agnostic exclusions (gaps, VDJ, errors, PAV inv.)",
+        ),
+        mpatches.Patch(
+            facecolor=C["asm_intersect"],
+            edgecolor="grey",
+            label="Assembly-intersect exclusions (segdups, TR, satellites)",
+        ),
+        mpatches.Patch(
+            facecolor=C["ref_agnostic"],
+            edgecolor="grey",
+            label="Ref-agnostic exclusions (flanks, SVs∩repeats, self-discrep)",
+        ),
+        mpatches.Patch(
+            facecolor=C["slop"], edgecolor="grey", label="Slop buffer (±15 kb)"
+        ),
+        mpatches.Patch(
+            facecolor=C["break"], edgecolor="grey", label="Assembly alignment break"
+        ),
     ]
-    fig.legend(handles=legend_elements, loc="lower center", ncol=3,
-               fontsize=7.5, frameon=True, edgecolor="#ccc",
-               bbox_to_anchor=(0.5, -0.02))
+    fig.legend(
+        handles=legend_elements,
+        loc="lower center",
+        ncol=3,
+        fontsize=7.5,
+        frameon=True,
+        edgecolor="#ccc",
+        bbox_to_anchor=(0.5, -0.02),
+    )
 
-    outpath = Path(__file__).resolve().parent.parent / "manuscript" / "figs" / "exclusion_diagram.png"
+    outpath = (
+        Path(__file__).resolve().parent.parent
+        / "manuscript"
+        / "figs"
+        / "exclusion_diagram.png"
+    )
     fig.savefig(outpath, dpi=300, bbox_inches="tight", facecolor="white")
     print(f"Saved to {outpath}")
     plt.close()

--- a/scripts/make_exclusion_diagram.py
+++ b/scripts/make_exclusion_diagram.py
@@ -34,8 +34,6 @@ Suggested IGV session setup:
 
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-from matplotlib.patches import FancyBboxPatch
-import numpy as np
 from pathlib import Path
 
 
@@ -394,7 +392,6 @@ def panel_b(ax):
     )
 
     # --- Subtraction arrow ---
-    y_arrow = 0.8
     ax.annotate(
         "",
         xy=(13.5, 0.55),

--- a/tests/unit/test_find_chr8_inversion.py
+++ b/tests/unit/test_find_chr8_inversion.py
@@ -15,8 +15,21 @@ def _syri_line(ref_start, ref_end, qry_start, qry_end, ann_type, chrom="chr8"):
     """Build a minimal 11-column SyRI .out line."""
     # SyRI columns (0-indexed): 0=refChr, 1=refStart, 2=refEnd, 5=qryChr,
     # 6=qryStart, 7=qryEnd, 10=type
-    return "\t".join([chrom, str(ref_start), str(ref_end), "-", "-",
-                      chrom, str(qry_start), str(qry_end), "-", "-", ann_type])
+    return "\t".join(
+        [
+            chrom,
+            str(ref_start),
+            str(ref_end),
+            "-",
+            "-",
+            chrom,
+            str(qry_start),
+            str(qry_end),
+            "-",
+            "-",
+            ann_type,
+        ]
+    )
 
 
 @pytest.fixture
@@ -25,6 +38,7 @@ def tmp_syri(tmp_path):
         p = tmp_path / "test.syri.out"
         p.write_text("\n".join(lines) + "\n")
         return str(p)
+
     return _write
 
 

--- a/workflow/scripts/make_chr8_figure.py
+++ b/workflow/scripts/make_chr8_figure.py
@@ -260,12 +260,9 @@ def assemble_figure(
 
     excl_label = ""
     if excl_start is not None and excl_end is not None:
-        excl_label = (
-            f"  |  Excluded: {excl_start / 1e6:.1f} – {excl_end / 1e6:.1f} Mb"
-        )
+        excl_label = f"  |  Excluded: {excl_start / 1e6:.1f} – {excl_end / 1e6:.1f} Mb"
     ax_b.set_title(
-        f"Zoomed: REF {ref_start / 1e6:.1f} – {ref_end / 1e6:.1f} Mb"
-        f"{excl_label}",
+        f"Zoomed: REF {ref_start / 1e6:.1f} – {ref_end / 1e6:.1f} Mb{excl_label}",
         fontsize=9,
         pad=4,
     )
@@ -320,10 +317,7 @@ def main():
         f"PAT {args.chrom}:{inv_start}-{inv_end}, "
         f"size {coords['size']:,} bp"
     )
-    print(
-        f"[INFO] Excluded region (PAV): "
-        f"REF {args.chrom}:{excl_start}-{excl_end}"
-    )
+    print(f"[INFO] Excluded region (PAV): REF {args.chrom}:{excl_start}-{excl_end}")
 
     sr_files = [args.syri_rm, args.syri_mp]
 


### PR DESCRIPTION
## Summary

- Added a companion `ggsave()` PDF call after every existing PNG `ggsave()` in all 6 Quarto analysis notebooks
- PDFs are saved to the same `manuscript/figs/` directory with the same filename stem (e.g. `var_len_dist.pdf` alongside `var_len_dist.png`)
- PDFs omit the `dpi` parameter since they are vector format; all other dimensions are preserved

## Affected notebooks (18 figures total)

| Notebook | Figures added |
|---|---|
| `analysis/benchmark_difficult.qmd` | `genomic_context_variant_counts`, `genomic_context_fold_change_by_size` |
| `analysis/benchmark_exclusions.qmd` | `grch38_exclusion_upset`, `grch38_exclusion_var_upset` |
| `analysis/benchmark_interval_size_distributions.qmd` | `benchmark_intervals` |
| `analysis/benchmarkset_characterization.qmd` | `var_len_dist`, `benchmark_region_size_change`, `combined_coverage_variant_change` |
| `analysis/external_evaluation.qmd` | `smvar_strat_flow`, `combined_eval`, `combined_eval_callset`, `ride_estimates`, `ride_estimates_callset` |
| `analysis/genomic_context_analysis.qmd` | `genomic_context_coverage`, `genomic_context_coverage_change` |
| `analysis/use_case_evaluation.qmd` | `use_case_smvar`, `use_case_stvar_ont`, `use_case_stvar_hifi` |

## Test plan

- [ ] Render one of the modified notebooks and verify both `.png` and `.pdf` files appear in `manuscript/figs/`
- [ ] Confirm PDF files open correctly and render as vector graphics

https://claude.ai/code/session_01GtmsjRS6yrLhk56KbnY4VD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtmsjRS6yrLhk56KbnY4VD)_